### PR TITLE
chore: Bump Kotlin to 2.1.0, Compose Multiplatform to 1.7.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 androidGradlePlugin = "8.7.3"
 androidx-activity-compose = "1.9.3"
-jetbrainsCompose = "1.7.1"
+jetbrainsCompose = "1.7.3"
 kotlin = "2.1.0"
 ktxml = "0.3.2"
 maven-publish = "0.30.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 androidGradlePlugin = "8.7.3"
 androidx-activity-compose = "1.9.3"
 jetbrainsCompose = "1.7.1"
-kotlin = "2.0.21"
+kotlin = "2.1.0"
 ktxml = "0.3.2"
 maven-publish = "0.30.0"
 

--- a/htmlconverter/build.gradle.kts
+++ b/htmlconverter/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -12,7 +11,6 @@ kotlin {
     explicitApi()
 
     jvm {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -11,7 +10,6 @@ plugins {
 
 kotlin {
     androidTarget {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }


### PR DESCRIPTION
Updates some core dependencies in advance of #8