### PR TITLE
feat: support for font color

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The default implementation uses the [KtXml](https://github.com/kobjects/ktxml) m
 
 ## Supported HTML tags
 
-- Inline tags with styling: `strong`, `b` (**bold**), `em`, `cite`, `dfn`, `i` (*italic*), `big` (bigger text), `small` (smaller text), `tt`, `code` (`monospace font`), `a` ([hyperlink](#supported-html-tags)), `u` (underline), `del`, `s`, `strike` (~~strikethrough~~), `sup` (<sup>supertext</sup>), `sub` (<sub>subtext</sub>)
+- Inline tags with styling: `strong`, `b` (**bold**), `em`, `cite`, `dfn`, `i` (*italic*), `big` (bigger text), `small` (smaller text), `tt`, `code` (`monospace font`), `font` (only support for color attribute with hexadecimal code), `a` ([hyperlink](#supported-html-tags)), `u` (underline), `del`, `s`, `strike` (~~strikethrough~~), `sup` (<sup>supertext</sup>), `sub` (<sub>subtext</sub>)
 - Block tags (paragraphs): `p`, `blockquote`, `pre` (including `monospace font`), `div`, `header`, `footer`, `main`, `nav`, `aside`, `section`, `article`, `address`, `figure`, `figcaption`, `video`, `audio` (no player shown, only inline text)
 - Horizontal rule: `hr` (no line drawn, but marks a new paragraph)
 - Lists: `ul`, `ol`, `li`, `dl`, `dt`, `dd`

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The default implementation uses the [KtXml](https://github.com/kobjects/ktxml) m
 
 ## Supported HTML tags
 
-- Inline tags with styling: `strong`, `b` (**bold**), `em`, `cite`, `dfn`, `i` (*italic*), `big` (bigger text), `small` (smaller text), `tt`, `code` (`monospace font`), `font` (only support for color attribute with hexadecimal code), `a` ([hyperlink](#supported-html-tags)), `u` (underline), `del`, `s`, `strike` (~~strikethrough~~), `sup` (<sup>supertext</sup>), `sub` (<sub>subtext</sub>)
+- Inline tags with styling: `strong`, `b` (**bold**), `em`, `cite`, `dfn`, `i` (*italic*), `big` (bigger text), `small` (smaller text), `tt`, `code` (`monospace font`), `span` (only support for style color attribute with hexadecimal code), `a` ([hyperlink](#supported-html-tags)), `u` (underline), `del`, `s`, `strike` (~~strikethrough~~), `sup` (<sup>supertext</sup>), `sub` (<sub>subtext</sub>)
 - Block tags (paragraphs): `p`, `blockquote`, `pre` (including `monospace font`), `div`, `header`, `footer`, `main`, `nav`, `aside`, `section`, `article`, `address`, `figure`, `figcaption`, `video`, `audio` (no player shown, only inline text)
 - Horizontal rule: `hr` (no line drawn, but marks a new paragraph)
 - Lists: `ul`, `ol`, `li`, `dl`, `dt`, `dd`

--- a/htmlconverter/src/commonMain/kotlin/be/digitalia/compose/htmlconverter/internal/AnnotatedStringHtmlHandler.kt
+++ b/htmlconverter/src/commonMain/kotlin/be/digitalia/compose/htmlconverter/internal/AnnotatedStringHtmlHandler.kt
@@ -109,7 +109,7 @@ internal class AnnotatedStringHtmlHandler(
             "sub" -> handleSpanStyleStart(SpanStyle(baselineShift = BaselineShift.Subscript))
             "h1", "h2", "h3", "h4", "h5", "h6" -> handleHeadingStart(name)
             "script", "head", "table", "form", "fieldset" -> handleSkippedTagStart()
-            "font" -> handleFontStart(attributes("color").orEmpty())
+            "span" -> handleSpanStart(attributes("style").orEmpty())
         }
     }
 
@@ -266,10 +266,15 @@ internal class AnnotatedStringHtmlHandler(
         }
     }
 
-    private fun handleFontStart(color: String) {
+    private fun extractHexColor(styleString: String): String {
+        val regex = Regex("""color:\s*(#[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?)""")
+        return regex.find(styleString)?.groupValues?.get(1) ?: ""
+    }
+
+    private fun handleSpanStart(style: String) {
         handleSpanStyleStart(
             SpanStyle(
-                color = color.toComposeColor()
+                color = extractHexColor(style).toComposeColor()
             )
         )
     }
@@ -295,7 +300,7 @@ internal class AnnotatedStringHtmlHandler(
             "small",
             "tt", "code",
             "u",
-            "del", "s", "strike", "font",
+            "del", "s", "strike", "span",
             "sup",
             "sub" -> handleSpanStyleEnd()
             "a" -> handleAnchorEnd()

--- a/htmlconverter/src/commonMain/kotlin/be/digitalia/compose/htmlconverter/internal/AnnotatedStringHtmlHandler.kt
+++ b/htmlconverter/src/commonMain/kotlin/be/digitalia/compose/htmlconverter/internal/AnnotatedStringHtmlHandler.kt
@@ -248,26 +248,19 @@ internal class AnnotatedStringHtmlHandler(
     }
 
     private fun String.toComposeColor(): Color {
-        val colorStr = this.removePrefix("#")
+        var colorStr = this.removePrefix("#")
+        if (colorStr.length == 8) colorStr = colorStr.drop(6) + colorStr.dropLast(2) // in compose, alpha digits are the two first
+        val colorInt = colorStr.toUIntOrNull(16) ?: return Color.Unspecified
+
         return when (colorStr.length) {
-            6 -> Color(
-                red = colorStr.substring(0, 2).toInt(16) / 255f,
-                green = colorStr.substring(2, 4).toInt(16) / 255f,
-                blue = colorStr.substring(4, 6).toInt(16) / 255f,
-                alpha = 1f
-            )
-            8 -> Color(
-                alpha = colorStr.substring(0, 2).toInt(16) / 255f,
-                red = colorStr.substring(2, 4).toInt(16) / 255f,
-                green = colorStr.substring(4, 6).toInt(16) / 255f,
-                blue = colorStr.substring(6, 8).toInt(16) / 255f
-            )
-            else -> Color.Black
+            6 -> Color(colorInt.toInt() or 0xFF000000.toInt())
+            8 -> Color(colorInt.toInt())
+            else -> Color.Unspecified
         }
     }
 
+    private val regex = Regex("""(?<!background-)color:\s*(#[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?)""")
     private fun extractHexColor(styleString: String): String {
-        val regex = Regex("""color:\s*(#[A-Fa-f0-9]{6}(?:[A-Fa-f0-9]{2})?)""")
         return regex.find(styleString)?.groupValues?.get(1) ?: ""
     }
 

--- a/sample/src/commonMain/kotlin/SampleHtml.kt
+++ b/sample/src/commonMain/kotlin/SampleHtml.kt
@@ -11,7 +11,7 @@ class SampleHtml {
                 <li><u>Underline</u></li>
                 <li><del>Strikethrough</del></li>
                 <li><code>Code</code></li>
-                <li>Text with <font color="#FF0000">some part</font> in another color</li>
+                <li>Text with <span style="color:#FF0000">some part</span> in another color</li>
                 <li><a href="https://www.wikipedia.org/">Hyperlink with custom styling</a></li>
                 <li><big>Bigger</big> and <small>smaller</small> text</li>
                 <li><sup>Super</sup>text and <sub>sub</sub>text</li>

--- a/sample/src/commonMain/kotlin/SampleHtml.kt
+++ b/sample/src/commonMain/kotlin/SampleHtml.kt
@@ -11,6 +11,7 @@ class SampleHtml {
                 <li><u>Underline</u></li>
                 <li><del>Strikethrough</del></li>
                 <li><code>Code</code></li>
+                <li>Text with <font color="#FF0000">some part</font> in another color</li>
                 <li><a href="https://www.wikipedia.org/">Hyperlink with custom styling</a></li>
                 <li><big>Bigger</big> and <small>smaller</small> text</li>
                 <li><sup>Super</sup>text and <sub>sub</sub>text</li>


### PR DESCRIPTION
Hi,
I've added support for **font** tag <font> with attribute **color** in hexadecimal format (no support for other font attributes)
It can be very useful for displaying multicolor text.
I need it for my project, and waiting for your remarks / approval
Many thanks !