### PR TITLE
add js, wasm, macos targets and a test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,36 @@ on:
     branches: [ "main" ]
 
 jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: jvm
+            os: ubuntu
+          - target: js
+            os: ubuntu
+          - target: wasmJs
+            os: ubuntu
+          - target: macosArm64
+            os: macos
+          - target: iosSimulatorArm64
+            os: macos
+    runs-on: "${{ matrix.os }}-latest"
+    name: "test (${{ matrix.target }})"
+    steps:
+      - name: Check out code
+        uses: "actions/checkout@v4"
+
+      - name: Set up JDK 21
+        uses: "actions/setup-java@v4"
+        with:
+          distribution: "temurin"
+          java-version: 21
+
+      - name: Test with Gradle
+        run: "./gradlew :htmlconverter:${{ matrix.target }}Test"
+
   build:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,11 @@ It can also be used to convert HTML to unstyled text.
 
 It can be considered as a multiplatform replacement for Android's [`Html.fromHtml()`](https://developer.android.com/reference/android/text/Html#fromHtml(java.lang.String,%20int)) API with support for more tags and better performance.
 
-| Platform      | Supported |
-|---------------|-----------|
-| Android       | ✅        |
-| Desktop (JVM) | ✅        |
-| iOS           | ✅        |
-| Web           | ❌        |
-
-The Web platform should use the [DOM wrapper API](https://kotlinlang.org/api/latest/jvm/stdlib/org.w3c.dom/) to insert HTML directly in the web page.
+| Platform                | Supported |
+|-------------------------|-----------|
+| JVM (Android & Desktop) | ✅        |
+| Native (iOS & macOS)    | ✅        |
+| Web (JS & WASM)         | ✅        |
 
 ## Running the sample app
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ androidGradlePlugin = "8.10.0"
 androidx-activity-compose = "1.10.1"
 jetbrainsCompose = "1.7.3"
 kotlin = "2.1.21"
-ktxml = "0.3.2"
+ktxml = "1.0.0"
 maven-publish = "0.32.0"
 
 [libraries]

--- a/htmlconverter/build.gradle.kts
+++ b/htmlconverter/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -13,6 +14,13 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+
+    js { browser() }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs { browser() }
 
     jvm {
         compilerOptions {
@@ -21,11 +29,17 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 implementation(compose.runtime)
                 implementation(compose.ui)
                 implementation(libs.ktxml)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
             }
         }
     }

--- a/htmlconverter/gradle.properties
+++ b/htmlconverter/gradle.properties
@@ -1,2 +1,4 @@
 POM_ARTIFACT_ID=htmlconverter
 POM_NAME=HTML Converter for Compose
+org.jetbrains.compose.experimental.jscanvas.enabled=true
+org.jetbrains.compose.experimental.macos.enabled=true

--- a/htmlconverter/src/commonTest/kotlin/be/digitalia/compose/htmlconverter/HtmlConverterTest.kt
+++ b/htmlconverter/src/commonTest/kotlin/be/digitalia/compose/htmlconverter/HtmlConverterTest.kt
@@ -1,0 +1,60 @@
+package be.digitalia.compose.htmlconverter
+
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HtmlConverterTest {
+    @Test
+    fun simpleTest() {
+        // language=html
+        val html = """
+            <a href="https://openfreemap.org" target="_blank">OpenFreeMap</a>
+            <a href="https://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>
+            Data from <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>
+        """.trimIndent().trim()
+
+        val expected = buildAnnotatedString {
+            pushLink(
+                LinkAnnotation.Url(
+                    url = "https://openfreemap.org",
+                    styles = TextLinkStyles(
+                        style = SpanStyle(textDecoration = TextDecoration.Underline)
+                    )
+                )
+            )
+            append("OpenFreeMap")
+            pop()
+
+            append(" ")
+            pushLink(
+                LinkAnnotation.Url(
+                    url = "https://www.openmaptiles.org/",
+                    styles = TextLinkStyles(
+                        style = SpanStyle(textDecoration = TextDecoration.Underline)
+                    )
+                )
+            )
+            append("© OpenMapTiles")
+            pop()
+
+            append(" Data from ")
+            pushLink(
+                LinkAnnotation.Url(
+                    url = "https://www.openstreetmap.org/copyright",
+                    styles = TextLinkStyles(
+                        style = SpanStyle(textDecoration = TextDecoration.Underline)
+                    )
+                )
+            )
+            append("OpenStreetMap")
+            pop()
+        }
+
+        assertEquals(expected, htmlToAnnotatedString(html))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,6 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
Updated KtXml to [the new version](https://github.com/kobjects/ktxml/releases/tag/v1.0.0) that supports all Kotlin Multiplatform targets, and added all targets that were missing here that Compose UI builds for. Will solve #13 when published.

Also added a unit test and a job to run it in CI on all platforms, to show it's working.

I didn't add these to the sample app, as you said you'd prefer to focus on stable plaforms. But I'd be happy to add them to the sample if requested.

